### PR TITLE
[JBPM-8624] - Bump Kubernetes Client version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -55,8 +55,8 @@
     <version.org.eclipse.jdt.core.compiler>4.6.1</version.org.eclipse.jdt.core.compiler>
     <version.com.github.javaparser>3.13.10</version.com.github.javaparser>
     <version.com.fasterxml.jackson>2.9.9</version.com.fasterxml.jackson>
-    <version.kubernetes-client>4.1.1</version.kubernetes-client>
-    <version.okhttp>3.9.0</version.okhttp>
+    <version.kubernetes-client>4.3.0</version.kubernetes-client>
+    <version.okhttp>3.12.0</version.okhttp>
     <version.io.prometheus>0.5.0</version.io.prometheus>
     <version.org.jboss.spec.javax.ws.rs.jboss-jaxrs-api_2.1_spec>1.0.1.Final</version.org.jboss.spec.javax.ws.rs.jboss-jaxrs-api_2.1_spec>
     <version.cz.xtf>0.11</version.cz.xtf>

--- a/pom.xml
+++ b/pom.xml
@@ -63,6 +63,7 @@
     <version.antapacheregexp>1.8.2</version.antapacheregexp>
 
     <version.io.quarkus>0.18.0</version.io.quarkus>
+    <version.com.oracle.substratevm>19.0.2</version.com.oracle.substratevm>
 
     <version.org.junit.minor>5.0</version.org.junit.minor> <!-- so that org.junit.platform and org.junit can share the same minor version -->
     <version.org.junit>5.${version.org.junit.minor}</version.org.junit>
@@ -469,6 +470,11 @@
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-junit5</artifactId>
         <version>${version.io.quarkus}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.oracle.substratevm</groupId>
+        <artifactId>svm</artifactId>
+        <version>${version.com.oracle.substratevm}</version>
       </dependency>
 
       <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -55,7 +55,7 @@
     <version.org.eclipse.jdt.core.compiler>4.6.1</version.org.eclipse.jdt.core.compiler>
     <version.com.github.javaparser>3.13.10</version.com.github.javaparser>
     <version.com.fasterxml.jackson>2.9.9</version.com.fasterxml.jackson>
-    <version.kubernetes-client>4.3.0</version.kubernetes-client>
+    <version.kubernetes-client>4.3.1</version.kubernetes-client>
     <version.okhttp>3.12.0</version.okhttp>
     <version.io.prometheus>0.5.0</version.io.prometheus>
     <version.org.jboss.spec.javax.ws.rs.jboss-jaxrs-api_2.1_spec>1.0.1.Final</version.org.jboss.spec.javax.ws.rs.jboss-jaxrs-api_2.1_spec>


### PR DESCRIPTION
See:
https://issues.jboss.org/browse/JBPM-8624

OkHttp dependency was bumped to be[ aligned with the Kube Client](https://mvnrepository.com/artifact/io.fabric8/kubernetes-client/4.3.0). Since those libraries are only used by Kogito Cloud and the work we're doing there is the motivation behind this PR, I believe it won't cause any harm to the Kogito Runtimes.