### PR TITLE
JBPM-8507 Upgrade jBPM modules to JUnit 5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -64,7 +64,7 @@
 
     <version.io.quarkus>0.15.0</version.io.quarkus>
 
-    <version.org.junit>5.4.2</version.org.junit>
+    <version.org.junit>5.5.0-RC2</version.org.junit>
     <version.org.junit.jupiter>${version.org.junit}</version.org.junit.jupiter>
     <version.org.junit.vintage>${version.org.junit}</version.org.junit.vintage>
     <version.org.assertj>3.8.0</version.org.assertj>


### PR DESCRIPTION
This PR upgrades JUnit to 5.5.0.RC2, which brings in the necessary support for declarative `@Timeout`s.

Part of an ensemble, merge together with https://github.com/kiegroup/kogito-runtimes/pull/76.