### PR TITLE
KOGITO-41 Some tests are not run when using JUnit 5.5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -64,9 +64,11 @@
 
     <version.io.quarkus>0.18.0</version.io.quarkus>
 
-    <version.org.junit>5.5.0-RC2</version.org.junit>
+    <version.org.junit.minor>5.0</version.org.junit.minor> <!-- so that org.junit.platform and org.junit can share the same minor version -->
+    <version.org.junit>5.${version.org.junit.minor}</version.org.junit>
     <version.org.junit.jupiter>${version.org.junit}</version.org.junit.jupiter>
     <version.org.junit.vintage>${version.org.junit}</version.org.junit.vintage>
+    <version.org.junit.platform>1.${version.org.junit.minor}</version.org.junit.platform> <!-- otherwise Quarkus brings its own, silently disabling some tests -->
     <version.org.assertj>3.8.0</version.org.assertj>
     <version.org.hamcrest>1.3</version.org.hamcrest> <!-- else old version coming from Mockito wins and breaks tests -->
     <version.org.mockito>1.10.19</version.org.mockito>
@@ -328,6 +330,20 @@
         <groupId>org.junit.jupiter</groupId>
         <artifactId>junit-jupiter-params</artifactId>
         <version>${version.org.junit.jupiter}</version>
+        <scope>test</scope>
+      </dependency>
+
+      <dependency>
+        <groupId>org.junit.platform</groupId>
+        <artifactId>junit-platform-engine</artifactId>
+        <version>${version.org.junit.platform}</version>
+        <scope>test</scope>
+      </dependency>
+
+      <dependency>
+        <groupId>org.junit.platform</groupId>
+        <artifactId>junit-platform-commons</artifactId>
+        <version>${version.org.junit.platform}</version>
         <scope>test</scope>
       </dependency>
 


### PR DESCRIPTION
Quarkus is on JUnit 5.4.2 and it brings JUnit Platform 1.4.2. We only
override JUnit itself, keeping the Platform from Quarkus - which, as it
turns out, silently disables Quarkus tests. By upgrading both JUnit and
its platform, we fix the issue.