### PR TITLE
Setup new XTF library version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -57,11 +57,11 @@
     <version.org.eclipse.jdt.core.compiler>4.6.1</version.org.eclipse.jdt.core.compiler>
     <version.com.github.javaparser>3.13.10</version.com.github.javaparser>
     <version.com.fasterxml.jackson>2.9.9</version.com.fasterxml.jackson>
-    <version.kubernetes-client>4.3.1</version.kubernetes-client>
+    <version.kubernetes-client>4.4.2</version.kubernetes-client>
     <version.okhttp>3.12.0</version.okhttp>
     <version.io.prometheus>0.5.0</version.io.prometheus>
     <version.org.jboss.spec.javax.ws.rs.jboss-jaxrs-api_2.1_spec>1.0.1.Final</version.org.jboss.spec.javax.ws.rs.jboss-jaxrs-api_2.1_spec>
-    <version.cz.xtf>0.11</version.cz.xtf>
+    <version.cz.xtf>0.13</version.cz.xtf>
     <version.antapacheregexp>1.8.2</version.antapacheregexp>
     <version.org.reflections>0.9.11</version.org.reflections>
     <version.javax.inject>1</version.javax.inject>


### PR DESCRIPTION
This new version works better with Kubernetes client 4.3.1 on OpenShift
3.x.
If you want want to use this library on OpenShift 4, need to update
Kubernetes client to 4.4.2 (with some known bugs from XTF team).