### PR TITLE
KOGITO-263 - Upgrade versions to align with Quarkus 0.22

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -69,7 +69,7 @@
     <version.org.infinispan>10.0.0.Beta3</version.org.infinispan>
     <version.org.infinispan.protostream>4.3.0.Alpha6</version.org.infinispan.protostream>
 
-    <version.io.quarkus>0.21.1</version.io.quarkus>
+    <version.io.quarkus>0.22.0</version.io.quarkus>
     <version.com.oracle.substratevm>19.2.0</version.com.oracle.substratevm>
     <version.io.smallrye.reactive>1.0.3</version.io.smallrye.reactive>
 


### PR DESCRIPTION
Placeholder PR for upgrading to Quarkus 0.22
Assembly:
- https://github.com/kiegroup/kogito-runtimes/pull/155
- https://github.com/kiegroup/kogito-bom/pull/56