### PR TITLE
Updated xtf and kubernetes-client

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -55,12 +55,12 @@
     <version.com.google.protobuf>3.6.1</version.com.google.protobuf>
     <version.org.eclipse.jdt>3.19.0</version.org.eclipse.jdt>
     <version.com.github.javaparser>3.13.10</version.com.github.javaparser>
-    <version.com.fasterxml.jackson>2.9.10</version.com.fasterxml.jackson>
-    <version.kubernetes-client>4.4.2</version.kubernetes-client>
+    <version.com.fasterxml.jackson>2.10.1</version.com.fasterxml.jackson>
+    <version.kubernetes-client>4.6.4</version.kubernetes-client>
     <version.okhttp>3.12.0</version.okhttp>
     <version.io.prometheus>0.5.0</version.io.prometheus>
     <version.org.jboss.spec.javax.ws.rs.jboss-jaxrs-api_2.1_spec>1.0.1.Final</version.org.jboss.spec.javax.ws.rs.jboss-jaxrs-api_2.1_spec>
-    <version.cz.xtf>0.13</version.cz.xtf>
+    <version.cz.xtf>0.14</version.cz.xtf>
     <version.antapacheregexp>1.8.2</version.antapacheregexp>
     <version.org.reflections>0.9.11</version.org.reflections>
     <version.javax.inject>1</version.javax.inject>

--- a/pom.xml
+++ b/pom.xml
@@ -55,8 +55,8 @@
     <version.com.google.protobuf>3.6.1</version.com.google.protobuf>
     <version.org.eclipse.jdt>3.19.0</version.org.eclipse.jdt>
     <version.com.github.javaparser>3.13.10</version.com.github.javaparser>
-    <version.com.fasterxml.jackson>2.10.1</version.com.fasterxml.jackson>
-    <version.kubernetes-client>4.6.4</version.kubernetes-client>
+    <version.com.fasterxml.jackson>2.9.10</version.com.fasterxml.jackson>
+    <version.kubernetes-client>4.6.2</version.kubernetes-client>
     <version.okhttp>3.12.0</version.okhttp>
     <version.io.prometheus>0.5.0</version.io.prometheus>
     <version.org.jboss.spec.javax.ws.rs.jboss-jaxrs-api_2.1_spec>1.0.1.Final</version.org.jboss.spec.javax.ws.rs.jboss-jaxrs-api_2.1_spec>


### PR DESCRIPTION
XTF 0.14 and kubernetes-client 4.6.4 bring more stability in communication to cluster
Jackson update is mandatory for kubernetes-client

Tested:
- [x] kogito-cloud
- [x] kogito-examples (onboarding)
~~- [ ] kogito-runtimes using new jackson 2.10.1~~ 