### PR TITLE
DROOLS-4087: added Jenkinsfile for deploy

### DIFF
--- a/Jenkinsfile.deploy
+++ b/Jenkinsfile.deploy
@@ -2,7 +2,7 @@
 
 pipeline {
     agent {
-        label 'submarine-static || kie-rhel7'
+        label 'kogito-static || kie-rhel7'
     }
     tools {
         maven 'kie-maven-3.5.4'

--- a/Jenkinsfile.deploy
+++ b/Jenkinsfile.deploy
@@ -1,0 +1,75 @@
+@Library('jenkins-pipeline-shared-libraries')_
+
+pipeline {
+    agent {
+        label 'submarine-static || kie-rhel7'
+    }
+    tools {
+        maven 'kie-maven-3.5.4'
+        jdk 'kie-jdk1.8'
+    }
+    options {
+        buildDiscarder logRotator(artifactDaysToKeepStr: '', artifactNumToKeepStr: '', daysToKeepStr: '', numToKeepStr: '5')
+        timeout(time: 90, unit: 'MINUTES')
+    }
+    stages {
+        stage('Initialize') {
+            steps {
+                sh 'printenv'
+            }
+        }
+        stage('Build kogito-bom') {
+            steps {
+                script {
+                    maven.runMavenWithSubmarineSettings('clean deploy', false)
+                }
+            }
+        }
+        stage('Build kogito-runtimes') {
+            steps {
+                checkout([$class: 'GitSCM', branches: [[name: 'master']], browser: [$class: 'GithubWeb', repoUrl: 'git@github.com:kiegroup/kogito-runtimes.git'], doGenerateSubmoduleConfigurations: false, extensions: [[$class: 'RelativeTargetDirectory', relativeTargetDir: 'kogito-runtimes']], submoduleCfg: [], userRemoteConfigs: [[credentialsId: 'kie-ci-user-key', url: 'git@github.com:kiegroup/kogito-runtimes.git']]])
+                dir("kogito-runtimes") {
+                    script {
+                      maven.runMavenWithSubmarineSettings('clean deploy', false)
+                    }
+                }
+            }
+        }
+        stage('Build kogito-cloud') {
+            steps {
+                checkout([$class: 'GitSCM', branches: [[name: 'master']], browser: [$class: 'GithubWeb', repoUrl: 'git@github.com:kiegroup/kogito-cloud.git'], doGenerateSubmoduleConfigurations: false, extensions: [[$class: 'RelativeTargetDirectory', relativeTargetDir: 'kogito-cloud']], submoduleCfg: [], userRemoteConfigs: [[credentialsId: 'kie-ci-user-key', url: 'git@github.com:kiegroup/kogito-cloud.git']]])
+                dir("kogito-cloud") {
+                    script {
+                        maven.runMavenWithSubmarineSettings('clean deploy', false)
+                    }
+                }
+            }
+        }
+        stage('Build kogito-examples') {
+            steps {
+                checkout([$class: 'GitSCM', branches: [[name: 'master']], browser: [$class: 'GithubWeb', repoUrl: 'git@github.com:kiegroup/kogito-examples.git'], doGenerateSubmoduleConfigurations: false, extensions: [[$class: 'RelativeTargetDirectory', relativeTargetDir: 'kogito-examples']], submoduleCfg: [], userRemoteConfigs: [[credentialsId: 'kie-ci-user-key', url: 'git@github.com:kiegroup/kogito-examples.git']]])
+                dir("kogito-runtimes") {
+                    script {
+                         maven.runMavenWithSubmarineSettings('clean deploy', false)
+                    }
+                }
+            }
+        }
+    }
+    post {
+        unstable {
+            script {
+                mailer.sendEmailFailure()
+            }
+        }
+        failure {
+            script {
+                mailer.sendEmailFailure()
+            }
+        }
+        always {
+            junit '**/target/surefire-reports/**/*.xml'
+            cleanWs()
+        }
+    }
+}


### PR DESCRIPTION
New Jenkinsfile (with pipeline)which deploys Kogito SNAPSHOTs to Nexus.
This can/should replace [kogito-pipeline-master](https://rhba-jenkins.rhev-ci-vms.eng.rdu2.redhat.com/job/KIE/job/master/job/kogito-deploy/job/kogito-pipeline-master/)
The actual deploy happens once a day. Probably the deploy should be start after each merged PR?
This should be easy to to since in pipeline you can trigger other jobs. WdyT?
This PR should be solve [DROOLS-4087](https://issues.redhat.com/browse/DROOLS-4087?filter=-1)